### PR TITLE
Removed UnitTesting from the dependency list

### DIFF
--- a/KDTree.quark
+++ b/KDTree.quark
@@ -5,6 +5,6 @@
 	\author: 		"Dan Stowell",
 	\country: 		"UK",
 	\helpdoc:		"KDTree.html",
-	\dependencies: ["UnitTesting"],
+	\dependencies: [""],
 	\since: 		"2007"
 )


### PR DESCRIPTION
UnitTesting is now in the official library, it is not needed as a dependency anymore.