### PR TITLE
Remove "UnitTesting" as dependency.

### DIFF
--- a/KDTree.quark
+++ b/KDTree.quark
@@ -5,6 +5,6 @@
 	\author: 		"Dan Stowell",
 	\country: 		"UK",
 	\helpdoc:		"KDTree.html",
-	\dependencies: ["UnitTesting"],
+	\dependencies: [],
 	\since: 		"2007"
 )


### PR DESCRIPTION
It's embed in SuperCollider already so you don't need to load that quark anymore.